### PR TITLE
Made operation name default to null.

### DIFF
--- a/src/GraphQLAction.php
+++ b/src/GraphQLAction.php
@@ -76,7 +76,7 @@ class GraphQLAction extends Action
             } else {
                 $this->query = $body['query'] ?? $body;
                 $this->variables = $body['variables'] ?? [];
-                $this->operationName = $body['operationName'] ?? [];
+                $this->operationName = $body['operationName'] ?? null;
             }
         }
         if (empty($this->query)) {


### PR DESCRIPTION
Sorry, with my previous pull request, I incorrectly set the operation to default to an array; which breaks queries without an operation name set.